### PR TITLE
Add CI workflow to test notebooks on pull requests

### DIFF
--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -1,0 +1,28 @@
+name: Test Notebooks
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test-notebooks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Run all notebooks
+        run: uv run .internal/run_notebooks.py
+
+      - name: Validate notebook execution counts
+        run: uv run python tests/test_notebook_execution.py

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -24,5 +24,5 @@ jobs:
       - name: Run all notebooks
         run: uv run .internal/run_notebooks.py
 
-      - name: Validate notebook execution counts
+      - name: Notebook tests
         run: uv run python tests/test_notebook_execution.py

--- a/tests/test_notebook_execution.py
+++ b/tests/test_notebook_execution.py
@@ -1,0 +1,99 @@
+"""
+Validate that all notebooks have been executed exactly once from start to finish.
+
+Checks:
+- Every code cell (except pip install cells) has a non-null execution_count.
+- Execution counts are sequential starting from 1 with no gaps or repeats,
+  which proves a single clean run from top to bottom.
+- Pip install cells have execution_count = None (skipped by run_notebooks.py).
+"""
+
+import sys
+from pathlib import Path
+
+import nbformat
+
+SKIP_MARKER = "pip install"
+
+# Notebooks excluded from validation (same as run_notebooks.py)
+SKIP_NOTEBOOKS = {"noaa-stations+gefs.ipynb"}
+
+
+def validate_notebook(notebook_path: Path) -> list[str]:
+    """Return a list of error messages (empty = pass)."""
+    nb = nbformat.read(notebook_path, as_version=4)
+    errors: list[str] = []
+
+    executed_counts: list[tuple[int, int]] = []  # (cell_index, execution_count)
+
+    for i, cell in enumerate(nb.cells):
+        if cell.cell_type != "code":
+            continue
+
+        is_pip_cell = SKIP_MARKER in cell.source
+
+        if is_pip_cell:
+            if cell.execution_count is not None:
+                errors.append(
+                    f"Cell {i}: pip install cell should have execution_count=None, "
+                    f"got {cell.execution_count}"
+                )
+            continue
+
+        if cell.execution_count is None:
+            errors.append(f"Cell {i}: execution_count is None (cell was not executed)")
+            continue
+
+        executed_counts.append((i, cell.execution_count))
+
+    if not executed_counts:
+        errors.append("No executed code cells found")
+        return errors
+
+    # Verify execution counts are strictly sequential (each increments by 1).
+    # They may not start at 1 if pip install cells consumed earlier counts.
+    for idx in range(1, len(executed_counts)):
+        prev_cell, prev_count = executed_counts[idx - 1]
+        curr_cell, curr_count = executed_counts[idx]
+        if curr_count != prev_count + 1:
+            errors.append(
+                f"Cell {curr_cell}: expected execution_count={prev_count + 1}, "
+                f"got {curr_count} (not sequential with cell {prev_cell})"
+            )
+
+    return errors
+
+
+def main() -> int:
+    root_dir = Path(__file__).parent.parent
+    notebooks = sorted(
+        p
+        for p in root_dir.glob("*.ipynb")
+        if p.name not in SKIP_NOTEBOOKS
+    )
+
+    if not notebooks:
+        print("ERROR: No notebooks found")
+        return 1
+
+    failed = False
+    for nb_path in notebooks:
+        errors = validate_notebook(nb_path)
+        if errors:
+            failed = True
+            print(f"FAIL: {nb_path.name}")
+            for err in errors:
+                print(f"  - {err}")
+        else:
+            print(f"OK:   {nb_path.name}")
+
+    if failed:
+        print("\nSome notebooks failed validation.")
+        return 1
+
+    print("\nAll notebooks passed validation.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_notebook_execution.py
+++ b/tests/test_notebook_execution.py
@@ -1,11 +1,14 @@
 """
-Validate that all notebooks have been executed exactly once from start to finish.
+Validate that all notebooks have been executed exactly once from a fresh kernel,
+top to bottom, with pip install cells skipped.
 
 Checks:
-- Every code cell (except pip install cells) has a non-null execution_count.
-- Execution counts are sequential starting from 1 with no gaps or repeats,
-  which proves a single clean run from top to bottom.
-- Pip install cells have execution_count = None (skipped by run_notebooks.py).
+- Pip install cells have execution_count=None and no outputs (not run).
+- Every other code cell has a non-null execution_count (was run).
+- The first executed cell's count is consistent with a fresh kernel
+  (1 if pip cells weren't executed, or pip_count + 1 if they were).
+- Execution counts are strictly sequential with no gaps or repeats,
+  proving a single clean run from top to bottom.
 """
 
 import sys
@@ -24,6 +27,7 @@ def validate_notebook(notebook_path: Path) -> list[str]:
     nb = nbformat.read(notebook_path, as_version=4)
     errors: list[str] = []
 
+    pip_cell_count = 0
     executed_counts: list[tuple[int, int]] = []  # (cell_index, execution_count)
 
     for i, cell in enumerate(nb.cells):
@@ -33,10 +37,15 @@ def validate_notebook(notebook_path: Path) -> list[str]:
         is_pip_cell = SKIP_MARKER in cell.source
 
         if is_pip_cell:
+            pip_cell_count += 1
             if cell.execution_count is not None:
                 errors.append(
                     f"Cell {i}: pip install cell should have execution_count=None, "
                     f"got {cell.execution_count}"
+                )
+            if cell.outputs:
+                errors.append(
+                    f"Cell {i}: pip install cell should have no outputs"
                 )
             continue
 
@@ -50,8 +59,21 @@ def validate_notebook(notebook_path: Path) -> list[str]:
         errors.append("No executed code cells found")
         return errors
 
-    # Verify execution counts are strictly sequential (each increments by 1).
-    # They may not start at 1 if pip install cells consumed earlier counts.
+    # Verify the notebook was run from a fresh kernel restart, top to bottom.
+    # A fresh kernel starts execution counts at 1. Pip install cells may or may
+    # not have consumed kernel counts (run_notebooks.py executes a no-op
+    # placeholder that consumes a count, but older runs may not have). The first
+    # executed cell's count must be consistent with a fresh kernel either way.
+    first_cell, first_count = executed_counts[0]
+    valid_first_counts = {1, pip_cell_count + 1}
+    if first_count not in valid_first_counts:
+        errors.append(
+            f"Cell {first_cell}: expected execution_count in {valid_first_counts} "
+            f"(fresh kernel with {pip_cell_count} pip cell(s)), "
+            f"got {first_count} — notebook may not have been run from a fresh kernel"
+        )
+
+    # Execution counts must be strictly sequential (each increments by 1).
     for idx in range(1, len(executed_counts)):
         prev_cell, prev_count = executed_counts[idx - 1]
         curr_cell, curr_count = executed_counts[idx]


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that runs all notebooks via `run_notebooks.py` on every PR to `main`
- Adds a validation script (`tests/test_notebook_execution.py`) that verifies every notebook has been executed exactly once by checking that execution counts are sequential with no gaps or repeats
- Pip install cells are expected to have `execution_count=None` (skipped by `run_notebooks.py`)

## Test plan

- [ ] Verify the workflow triggers on PRs to main
- [ ] Confirm all notebooks execute successfully in CI
- [ ] Confirm the execution count validation catches notebooks that haven't been run

https://claude.ai/code/session_013srkRwyvnZ37g5jTXm4Xk6