### PR TITLE
Fix NOAA HRRR forecast 48-hour virtual notebook title

### DIFF
--- a/noaa-hrrr-forecast-48-hour-virtual.ipynb
+++ b/noaa-hrrr-forecast-48-hour-virtual.ipynb
@@ -5,7 +5,7 @@
    "id": "69d242b6",
    "metadata": {},
    "source": [
-    "# Quickstart: NOAA HRRR forecast, 48 hour - dynamical.org Icechunk Zarr\n",
+    "# Quickstart: NOAA HRRR forecast, 48 hour, virtual - dynamical.org Icechunk Zarr\n",
     "\n",
     "NOAA's High-Resolution Rapid Refresh (HRRR) is a convection-allowing weather model covering the contiguous United States at 3 km resolution. At that resolution it resolves individual thunderstorms, which makes it the go-to model in the US for severe weather, snow bands, and other fine-scale phenomena. This dataset provides the 48-hour forecasts, initialized every 6 hours, from July 2018 to present, transformed into an analysis-ready cloud-optimized Icechunk Zarr by [dynamical.org](https://dynamical.org).\n",
     "\n",


### PR DESCRIPTION
The quickstart heading in `noaa-hrrr-forecast-48-hour-virtual.ipynb` was missing `, virtual`, so it read "NOAA HRRR forecast, 48 hour" instead of the full dataset name "NOAA HRRR forecast, 48 hour, virtual".

This one-line change corrects the markdown title to match the dataset name (`ds.attrs["name"]`) and the dataset documentation link already in the notebook.

Fixes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WtxiyrXKQCVgdMt49nQ1rc)_