### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -10,10 +10,10 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4
 
       - name: Set up Python
         run: uv python install 3.12


### PR DESCRIPTION
Pins every tag-pinned `uses:` ref in this repo to the full-length commit SHA the tag currently points at, with the tag preserved as a trailing comment.

The org-level Actions policy now has **Require actions to be pinned to a full-length commit SHA** enabled. Tag-pinned refs are rejected at run startup with an opaque "workflow file issue" error, so this repo's workflows cannot run until they are pinned.

SHAs were resolved from the tags that were previously in use, so behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)