### PR TITLE
Open HRDPS via dynamical_catalog

### DIFF
--- a/eccc-hrdps-forecast.ipynb
+++ b/eccc-hrdps-forecast.ipynb
@@ -30,7 +30,7 @@
    "source": [
     "# If running locally, follow README.md for simple dependency installation.\n",
     "# If using Google Colab, run this cell.\n",
-    "!uv pip install dynamical-catalog cartopy"
+    "!uv pip install dynamical-catalog rioxarray pyproj"
    ]
   },
   {
@@ -700,21 +700,9 @@
     }
    ],
    "source": [
-    "import icechunk\n",
-    "import xarray as xr\n",
+    "import dynamical_catalog\n",
     "\n",
-    "# Not in the STAC catalog yet. Once it is, this whole cell becomes:\n",
-    "#     import dynamical_catalog\n",
-    "#\n",
-    "#     ds = dynamical_catalog.open(\"eccc-hrdps-forecast\", chunks=None)\n",
-    "#     ds\n",
-    "storage = icechunk.s3_storage(\n",
-    "    bucket=\"dynamical-eccc-hrdps\",\n",
-    "    prefix=\"eccc-hrdps-forecast/v0.1.0.icechunk\",\n",
-    "    region=\"us-west-2\",\n",
-    "    anonymous=True,\n",
-    ")\n",
-    "ds = xr.open_zarr(icechunk.Repository.open(storage).readonly_session(\"main\").store, chunks=None)\n",
+    "ds = dynamical_catalog.open(\"eccc-hrdps-forecast\", chunks=None)\n",
     "ds"
    ]
   },


### PR DESCRIPTION
`eccc-hrdps-forecast` is in the production catalog as of dynamical-org/dynamical-stac#91, so the quickstart opens it the way every other notebook does.

The open cell goes from fourteen lines of bucket, prefix, region and session plumbing to:

```python
import dynamical_catalog

ds = dynamical_catalog.open("eccc-hrdps-forecast", chunks=None)
ds
```

`icechunk` and `xarray` are no longer imported; neither is used anywhere else in the notebook.

## Install line

It asked for `cartopy`, which this notebook never imports, and omitted `rioxarray`, which it does import for the `.rio` accessor. CI installs the repo's own dependencies, so only a Colab reader would have hit the missing one. Now `dynamical-catalog rioxarray pyproj`, matching `noaa-hrrr-forecast-48-hour.ipynb`. `pyproj` is listed explicitly because the notebook imports `Transformer` directly, rather than relying on it arriving through `rioxarray`.

Verified before opening this: `dynamical_catalog.open("eccc-hrdps-forecast")` resolves against the production catalog, with AWS environment variables unset, returning 215 init times and 17 variables.