### PR TITLE
Check the Colab install lines, statically and by running against them

### DIFF
--- a/.internal/check_install_lines.py
+++ b/.internal/check_install_lines.py
@@ -1,0 +1,50 @@
+"""
+Check every notebook's Colab install line against pyproject's dependencies.
+
+CI runs notebooks against the repo's environment, so an install line can name a
+package the repo does not have, or omit one the notebook imports, and stay green
+while every Colab reader hits an ImportError.
+
+This catches the first half statically. `run_notebooks.py --isolated` catches the
+second by running each notebook against only what its install line asks for.
+
+Usage:
+    uv run .internal/check_install_lines.py
+"""
+
+import sys
+
+from notebook_deps import ROOT, install_line_packages, normalize, project_dependencies
+
+
+def main() -> int:
+    declared = project_dependencies()
+    problems: list[str] = []
+
+    for notebook_path in sorted(ROOT.glob("*.ipynb")):
+        packages = install_line_packages(notebook_path)
+        if packages is None:
+            continue
+        undeclared = sorted(
+            {normalize(p) for p in packages} - declared - {"uv"}
+        )
+        if undeclared:
+            problems.append(f"{notebook_path.name}: {', '.join(undeclared)}")
+
+    if problems:
+        print("Install line packages missing from pyproject dependencies:\n")
+        for problem in problems:
+            print(f"  {problem}")
+        print(
+            "\nAdd them to [project.dependencies] so the environment CI runs "
+            "matches what a Colab reader installs, or drop them from the "
+            "install line if the notebook does not need them."
+        )
+        return 1
+
+    print(f"All install lines are covered by pyproject dependencies.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.internal/notebook_deps.py
+++ b/.internal/notebook_deps.py
@@ -1,0 +1,51 @@
+"""
+Read the packages each notebook asks a Colab reader to install.
+
+Every notebook carries a cell like:
+
+    !uv pip install dynamical-catalog rioxarray
+
+That line is the only dependency declaration a Colab reader ever sees, and CI
+installs the repo's own dependencies instead, so nothing checks it.
+"""
+
+import json
+import re
+from pathlib import Path
+
+INSTALL_MARKER = "uv pip install"
+
+ROOT = Path(__file__).parent.parent
+
+# Runner requirements, added to every isolated environment. A notebook does not
+# import these; nbclient needs them to start a kernel and read the file.
+RUNNER_PACKAGES = ("nbclient", "nbformat", "ipykernel")
+
+
+def normalize(name: str) -> str:
+    """PyPI treats runs of -_. as equal and is case insensitive (PEP 503)."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def install_line_packages(notebook_path: Path) -> tuple[str, ...] | None:
+    """Packages from the notebook's `uv pip install` cell, or None if it has no such cell."""
+    notebook = json.loads(notebook_path.read_text())
+    for cell in notebook["cells"]:
+        source = "".join(cell["source"])
+        if INSTALL_MARKER not in source:
+            continue
+        line = next(l for l in source.splitlines() if INSTALL_MARKER in l)
+        args = line.split(INSTALL_MARKER, 1)[1].split()
+        return tuple(a for a in args if not a.startswith("-"))
+    return None
+
+
+def project_dependencies() -> set[str]:
+    """Normalized names from pyproject's [project.dependencies]."""
+    import tomllib
+
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    return {
+        normalize(re.split(r"[<>=!~\[ ]", dep)[0])
+        for dep in pyproject["project"]["dependencies"]
+    }

--- a/.internal/run_notebooks.py
+++ b/.internal/run_notebooks.py
@@ -5,24 +5,105 @@ Clears all outputs first, then runs and saves with updated outputs.
 
 Usage:
     uv run python .internal/run_notebooks.py [notebook1.ipynb notebook2.ipynb ...]
+    uv run python .internal/run_notebooks.py --isolated
 
 If no notebooks are specified, runs all notebooks in the root directory.
+
+`--isolated` runs each notebook against only the packages its own Colab install
+line names, rather than the repo environment, so an install line that omits
+something the notebook imports fails here instead of on a reader's first run.
+Notebooks are grouped by install line, so the 21 notebooks need a handful of
+environments rather than one each, and uv caches them between runs.
 """
 
+import os
+import subprocess
 import sys
+import tempfile
+from collections import defaultdict
 from pathlib import Path
 
-import nbformat
-from nbclient import NotebookClient
+from notebook_deps import RUNNER_PACKAGES, install_line_packages
 
 SKIP_MARKER = "pip install"
 
 # Notebooks to skip by default (e.g. one-off or WIP notebooks)
 SKIP_NOTEBOOKS = {"noaa-stations+gefs.ipynb"}
 
+KERNEL_NAME = "isolated"
 
-def run_notebook(notebook_path: Path) -> None:
+
+def run_group(packages: tuple[str, ...], notebooks: list[Path]) -> bool:
+    """Run `notebooks` against only `packages`. Returns True if they all passed.
+
+    Builds an explicit throwaway environment rather than layering onto the
+    project one. `uv run --with` discovers the repo's .venv and would let the
+    notebook import packages its install line never named, so the check would
+    pass no matter what the install line said.
+
+    The kernel must come from that environment too: nbclient resolves the stock
+    "python3" kernel to whichever jupyter finds first, so install a kernelspec
+    into the throwaway environment and point JUPYTER_PATH at it.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        env_dir = Path(tmp) / "env"
+        kernels = Path(tmp) / "kernels"
+        python = env_dir / "bin" / "python"
+
+        subprocess.run(["uv", "venv", "-q", str(env_dir)], check=True)
+        subprocess.run(
+            ["uv", "pip", "install", "-q", "--python", str(python),
+             *packages, *RUNNER_PACKAGES],
+            check=True,
+        )
+        subprocess.run(
+            [str(python), "-m", "ipykernel", "install",
+             "--prefix", str(kernels), "--name", KERNEL_NAME],
+            check=True, capture_output=True,
+        )
+
+        env = dict(os.environ, JUPYTER_PATH=str(kernels / "share" / "jupyter"))
+        env.pop("VIRTUAL_ENV", None)
+        result = subprocess.run(
+            [str(python), str(Path(__file__).resolve()),
+             "--kernel", KERNEL_NAME, *(str(n.resolve()) for n in notebooks)],
+            env=env, check=False,
+        )
+    return result.returncode == 0
+
+
+def run_isolated(notebooks: list[Path]) -> int:
+    """Run each notebook against only its own install line. Returns an exit code."""
+    groups: dict[tuple[str, ...], list[Path]] = defaultdict(list)
+    for notebook_path in notebooks:
+        packages = install_line_packages(notebook_path)
+        if packages is None:
+            print(f"Skipping {notebook_path.name}: no install line to isolate against")
+            continue
+        groups[packages].append(notebook_path)
+
+    failures: list[str] = []
+    for packages, group in sorted(groups.items()):
+        print(f"\n=== {' '.join(packages)} ({len(group)} notebook(s)) ===", flush=True)
+        if not run_group(packages, group):
+            failures.extend(n.name for n in group)
+
+    if failures:
+        print("\nFailed against their own install line:")
+        for name in failures:
+            print(f"  {name}")
+        return 1
+    print("\nEvery notebook ran against only what its install line names.")
+    return 0
+
+
+def run_notebook(notebook_path: Path, kernel_name: str = "python3") -> None:
     print(f"Running {notebook_path.name}...")
+
+    # Imported here, not at module scope: --isolated orchestrates throwaway
+    # environments using only the standard library, and installs these into each.
+    import nbformat
+    from nbclient import NotebookClient
 
     nb = nbformat.read(notebook_path, as_version=4)
 
@@ -44,7 +125,7 @@ def run_notebook(notebook_path: Path) -> None:
     client = NotebookClient(
         nb,
         timeout=600,
-        kernel_name="python3",
+        kernel_name=kernel_name,
         resources={"metadata": {"path": str(notebook_path.parent)}},
     )
 
@@ -66,19 +147,33 @@ def run_notebook(notebook_path: Path) -> None:
         print(f"  ⚠ WARNING: {notebook_path.name} is too large ({size_mb:.1f} MB). Reduce notebook size.")
 
 
-def main():
+def main() -> int:
     root_dir = Path(__file__).parent.parent
+    args = sys.argv[1:]
 
-    if len(sys.argv) > 1:
-        notebooks = [Path(arg) for arg in sys.argv[1:]]
+    isolated = "--isolated" in args
+    args = [a for a in args if a != "--isolated"]
+
+    kernel_name = "python3"
+    if "--kernel" in args:
+        index = args.index("--kernel")
+        kernel_name = args[index + 1]
+        del args[index : index + 2]
+
+    if args:
+        notebooks = [Path(arg) for arg in args]
     else:
         notebooks = sorted(
             p for p in root_dir.glob("*.ipynb") if p.name not in SKIP_NOTEBOOKS
         )
 
+    if isolated:
+        return run_isolated(notebooks)
+
     for nb_path in notebooks:
-        run_notebook(nb_path)
+        run_notebook(nb_path, kernel_name)
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
Draft: the mechanism works and is verified, but adopting it means fixing the install lines it finds, and I have not done that here.

## The gap

`test-notebooks` runs notebooks against the repo's own dependencies, so the `!uv pip install ...` line is never exercised. A notebook can be green in CI and broken for every Colab reader. The HRDPS quickstart had it both ways at once: it asked for `cartopy`, which it never imports, and omitted `rioxarray`, which it does.

## Two checks

**`check_install_lines.py`** — static, instant. Every package named in an install line must appear in `[project.dependencies]`, so the environment CI runs matches what a reader installs. Today it reports:

```
noaa-hrrr-analysis.ipynb: pyproj
noaa-hrrr-forecast-48-hour.ipynb: pyproj
noaa-stations+gefs.ipynb: geopandas, requests, xvec
```

`pyproj` arrives transitively through `rioxarray`, so those two work by luck rather than declaration.

**`run_notebooks.py --isolated`** — runs each notebook against only what its own line names. There are 21 notebooks and 8 distinct install lines (11 share `dynamical-catalog` alone), so notebooks are grouped by line: 8 environments, not 21, and uv caches them between runs.

## Two ways this silently does nothing, both hit while building it

Worth knowing, because each produced a check that passed while proving nothing:

- **`uv run --no-project --with ...` does not isolate.** It discovers the repo's `.venv` and the notebook imports whatever is in it. Stripping `VIRTUAL_ENV` and the venv's `PATH` entry does not help. The environment has to be built explicitly with `uv venv` plus `uv pip install --python`.
- **nbclient's default kernel is not the environment you just built.** `kernel_name="python3"` resolves to whichever kernelspec jupyter finds first, typically the project's. A kernelspec has to be installed into the throwaway environment with `JUPYTER_PATH` pointed at it.

Verified both directions: a notebook whose line omits an import it uses fails with that import's `ModuleNotFoundError` from inside the cell, and the same notebook passes once the line names it.

## Not done here

- The install lines above are unfixed, so `check_install_lines.py` exits 1 on `main` today.
- Neither check is wired into `.github/workflows/test-notebooks.yml`.
- `--isolated` has not been run across all 21 notebooks. It will likely surface more incomplete lines, which is the point, but someone should see the list before it gates CI.
- Runtime is unmeasured at full scale. Environment creation is cached and cheap; the notebook execution dominates and is unchanged.